### PR TITLE
optimize

### DIFF
--- a/packages/orthodox/index.js
+++ b/packages/orthodox/index.js
@@ -1,5 +1,8 @@
-module.exports = (style) => (
-  Object.keys(style)
-    .map(property => `${property}:${style[property]}`)
-    .join(';')
-);
+module.exports = function serialize(style) {
+  var result = ''
+  for (var property in style) {
+    if (result) result += ';'
+    result += property + ':' + style[property]
+  }
+  return result
+}


### PR DESCRIPTION
hi, i liked the idea behind this package but i thought the implementation looked a little rough. Turns out replacing `Object.keys` and `map` with a standard (backwards-compatible!) `for...in` loop made it 12x faster:
```md
# old version 1000000 times
ok ~1.29 s (1 s + 292547804 ns)

# new version 1000000 times
ok ~106 ms (0 s + 106210239 ns)
```